### PR TITLE
Bomb Parity Prediction Refactor

### DIFF
--- a/JoshaParity/BeatGrid.cs
+++ b/JoshaParity/BeatGrid.cs
@@ -1,0 +1,109 @@
+﻿using System.Numerics;
+using JoshaUtils;
+
+namespace JoshaParity
+{
+    /// <summary>
+    /// Representation of the grid
+    /// </summary>
+    public class BeatGrid
+    {
+        private readonly Dictionary<Vector2, Vector2> _positionToAvoidanceVector = new()
+        {
+        { new Vector2(0, 0), new Vector2(1, 1) },
+        { new Vector2(0, 1), new Vector2(1, 0) },
+        { new Vector2(0, 2), new Vector2(1, -1) },
+        { new Vector2(1, 0), new Vector2(0, 2) },
+        { new Vector2(1, 1), new Vector2(1, 0) },
+        { new Vector2(1, 2), new Vector2(0, -2) },
+        { new Vector2(2, 0), new Vector2(0, 2) },
+        { new Vector2(2, 1), new Vector2(-1, 0) },
+        { new Vector2(2, 2), new Vector2(0, -2) },
+        { new Vector2(3, 0), new Vector2(-1, -1) },
+        { new Vector2(3, 1), new Vector2(0, -1) },
+        { new Vector2(3, 2), new Vector2(-1, -1) },
+        };
+
+        // Returns true if the inputted note and bomb coordinates cause a reset potentially
+        private readonly Dictionary<int, Func<Vector2, int, int, Parity, bool>> _bombDetectionConditions = new()
+        {
+        { 0, (note, x, y, parity) => ((y >= note.Y && y != 0) || (y > note.Y && y > 0)) && x == note.X },
+        { 1, (note, x, y, parity) => ((y <= note.Y && y != 2) || (y < note.Y && y < 2)) && x == note.X },
+        { 2, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.Y || y == note.Y - 1) && ((note.X != 3 && x < note.X) || (note.X < 3 && x <= note.X))) ||
+                                     (parity == Parity.Backhand && y == note.Y && ((note.X != 0 && x < note.X) || (note.X > 0 && x <= note.X))) },
+        { 3, (note, x, y, parity) => (parity == Parity.Forehand && (y == note.Y || y == note.Y - 1) && ((note.X != 0 && x > note.X) || (note.X > 0 && x >= note.X))) ||
+                                     (parity == Parity.Backhand && y == note.Y && ((note.X != 3 && x > note.X) || (note.X < 3 && x >= note.X))) },
+        { 4, (note, x, y, parity) => ((y >= note.Y && y != 0) || (y > note.Y && y > 0)) && x == note.X && !(x == 3 && y is 1) && parity != Parity.Forehand },
+        { 5, (note, x, y, parity) => ((y >= note.Y && y != 0) || (y > note.Y && y > 0)) && x == note.X && !(x == 0 && y is 1) && parity != Parity.Forehand },
+        { 6, (note, x, y, parity) => ((y <= note.Y && y != 2) || (y < note.Y && y < 2)) && x == note.X && !(x == 3 && y is 1) && parity != Parity.Backhand },
+        { 7, (note, x, y, parity) => ((y <= note.Y && y != 2) || (y < note.Y && y < 2)) && x == note.X && !(x == 0 && y is 1) && parity != Parity.Backhand },
+        { 8, (note,x,y, parity) => false }
+        };
+
+        private readonly List<GridPosition> _positions;
+        public float Time { get; }
+
+        public BeatGrid(List<Bomb> bombs, float timeStamp)
+        {
+            _positions = new List<GridPosition>();
+            Time = timeStamp;
+            for (int i = 0; i < 4; i++)
+            {
+                for (int j = 0; j < 3; j++)
+                {
+                    GridPosition newPosition = new() { x = i, y = j, bomb = false };
+                    _positions.Add(newPosition);
+                }
+            }
+
+            foreach (Bomb bomb in bombs)
+            {
+                _positions.First(x => x.x == bomb.x && x.y == bomb.y).bomb = true;
+            }
+        }
+
+        public bool BombCheckResetIndication(List<GridPosition> positionsWithBombs, Vector2 handPos, int inferredCutDir, Parity lastParity, int xPlayerOffset = 0)
+        {
+
+            foreach (Vector2 bombPos in positionsWithBombs.Select(t => new Vector2(t.x, t.y)))
+            {
+                // If in the center 2 grid spaces, no point trying
+                if ((bombPos.X is 1 or 2) && bombPos.Y is 1) return false;
+
+                // If we already found reason to reset, no need to try again
+                bool bombResetIndicated = _bombDetectionConditions[inferredCutDir](new Vector2(handPos.X, handPos.Y), (int)(bombPos.X - (xPlayerOffset * 2)), (int)bombPos.Y, lastParity);
+                if (bombResetIndicated) return true;
+            }
+            return false;
+        }
+
+        // Calculate if saber movement needed
+        public Vector3 SaberUpdateCalc(Vector2 handPos, int inferredCutDir, Parity lastParity, int xPlayerOffset = 0)
+        {
+            // Check if given hand position and inferred cut direction this is any reset indication
+            List<GridPosition> positionsWithBombs = _positions.FindAll(x => x.bomb);
+            bool resetIndication =
+                BombCheckResetIndication(positionsWithBombs, handPos, inferredCutDir, lastParity, xPlayerOffset);
+
+            // If there is an inferred reset, we will pretend to reset the player
+            bool parityFlip = false;
+            Vector2 awayFromBombVector = new(0, 0);
+            if (resetIndication)
+            {
+                awayFromBombVector = _positionToAvoidanceVector[new Vector2(handPos.X, handPos.Y)];
+                parityFlip = true;
+            }
+
+            handPos.X = Math.Clamp(handPos.X + awayFromBombVector.X, 0, 3);
+            handPos.X = Math.Clamp(handPos.X + awayFromBombVector.Y, 0, 2);
+
+            return (parityFlip) ? new Vector3(handPos.X, handPos.Y, 1) : new Vector3(handPos.X, handPos.Y, 0);
+        }
+    }
+
+    public class GridPosition
+    {
+        public bool bomb;
+        public int x, y;
+    }
+}

--- a/JoshaParity/BeatGrid.cs
+++ b/JoshaParity/BeatGrid.cs
@@ -64,7 +64,6 @@ namespace JoshaParity
 
         public bool BombCheckResetIndication(List<GridPosition> positionsWithBombs, Vector2 handPos, int inferredCutDir, Parity lastParity, int xPlayerOffset = 0)
         {
-
             foreach (Vector2 bombPos in positionsWithBombs.Select(t => new Vector2(t.x, t.y)))
             {
                 // If in the center 2 grid spaces, no point trying
@@ -95,7 +94,7 @@ namespace JoshaParity
             }
 
             handPos.X = Math.Clamp(handPos.X + awayFromBombVector.X, 0, 3);
-            handPos.X = Math.Clamp(handPos.X + awayFromBombVector.Y, 0, 2);
+            handPos.Y = Math.Clamp(handPos.Y + awayFromBombVector.Y, 0, 2);
 
             return (parityFlip) ? new Vector3(handPos.X, handPos.Y, 1) : new Vector3(handPos.X, handPos.Y, 0);
         }

--- a/JoshaParity/GenericParityCheck.cs
+++ b/JoshaParity/GenericParityCheck.cs
@@ -39,7 +39,7 @@ namespace JoshaParity
                 SwingDataGeneration.ForehandDict[lastSwing.notes[0].d];
 
             int orient = nextNote.d;
-            if (nextNote.d == 8) SwingDataGeneration.CutDirFromAngle(lastSwing.endPos.rotation, lastSwing.swingParity, 45.0f);
+            if (nextNote.d == 8) orient = SwingDataGeneration.CutDirFromAngle(lastSwing.endPos.rotation, lastSwing.swingParity, 45.0f);
 
             float nextAFN = (lastSwing.swingParity == Parity.Forehand) ?
                 SwingDataGeneration.BackhandDict[orient] :

--- a/JoshaParity/GenericParityCheck.cs
+++ b/JoshaParity/GenericParityCheck.cs
@@ -114,11 +114,15 @@ namespace JoshaParity
                 bool bombResetIndicated = simulatedParity != lastSwing.swingParity;
                 if (!bombResetIndicated) continue;
 
-                // Perform a check on the angle change to determine if angle similarity means reset
+                // Performs a check to check occassional false flags that are likely unintended
                 if (nextNote.d != 8)
                 {
-                    // First Check, is the end AFN (Angle from neutral) going to NOT be >= 90? (rotated 90 degrees inwards or outwards)
-                    if (!(MathF.Abs(AFNChange) >= 90)) continue;
+                    // Depending on parity, check the ending AFN (Angle from neutral).
+                    // In most cases, we will assume that only forehand resets with bombs occur
+                    // when the AFN is >= 90. For backhand, limit further. Furthermore, backhand / up
+                    // resets are more unconventional.
+                    if (simulatedParity == Parity.Forehand && (!(MathF.Abs(AFNChange) >= 90))) continue;
+                    if (simulatedParity == Parity.Backhand && (!(MathF.Abs(AFNChange) >= 45))) continue;
                 }
 
                 // If the last and next swing are just singular dots, perform angle clamping to the sabers

--- a/JoshaParity/IParityMethod.cs
+++ b/JoshaParity/IParityMethod.cs
@@ -4,7 +4,7 @@ namespace JoshaParity
 {
     public interface IParityMethod
     {
-        PARITY_STATE ParityCheck(SwingData lastCut, ref SwingData currentSwing, List<Bomb> bombs, int playerXOffset, bool rightHand, float timeTillNextNote = 0.1f);
+        Parity ParityCheck(SwingData lastCut, ref SwingData currentSwing, List<Bomb> bombs, int playerXOffset, bool rightHand, float timeTillNextNote = 0.1f);
         bool UpsideDown { get; }
     }
 }

--- a/JoshaParity/MapLoader.cs
+++ b/JoshaParity/MapLoader.cs
@@ -93,31 +93,30 @@ namespace JoshaUtils
             string diffFilePath = mapFolder + "/" + difficulty._beatmapFilename;
             DifficultyV3? loadedDiff = LoadJSON<DifficultyV3>(diffFilePath);
 
-            if (loadedDiff != null)
+            // If null, just return an empty map file
+            if (loadedDiff == null) return emptyMap;
+
+            // Attempt to get difficulty data via conversion from V2 to V3
+            if (string.IsNullOrEmpty(loadedDiff.version))
             {
-                // Attempt to get difficulty data via conversion from V2 to V3
-                if (loadedDiff.version == null || loadedDiff.version.Length == 0)
-                {
-                    DifficultyV2? V2Diff = LoadJSON<DifficultyV2>(diffFilePath);
-                    if (V2Diff != null) loadedDiff = MapStructureUtils.ConvertV2ToV3(V2Diff);
-                }
-
-                // If still null
-                if (loadedDiff.version == null || loadedDiff.version.Length == 0)
-                {
-                    loadedDiff = new();
-                    Console.WriteLine("Was unable to load \"" + diffFilePath + "\" as either V3 or V2 format. Both failed to parse to JSON.");
-                }
-
-                // Construct map data and send back
-                MapData map = new();
-                map.Metadata = difficulty;
-                map.Metadata.mapName = SanitizeFilename(mapData._songName);
-                map.Metadata.songFilename = mapData._songFilename;
-                map.DifficultyData = loadedDiff;
-                return map;
+                DifficultyV2? V2Diff = LoadJSON<DifficultyV2>(diffFilePath);
+                if (V2Diff != null) loadedDiff = MapStructureUtils.ConvertV2ToV3(V2Diff);
             }
-            return emptyMap;
+
+            // If still null
+            if (string.IsNullOrEmpty(loadedDiff.version))
+            {
+                loadedDiff = new();
+                Console.WriteLine("Was unable to load \"" + diffFilePath + "\" as either V3 or V2 format. Both failed to parse to JSON.");
+            }
+
+            // Construct map data and send back
+            MapData map = new();
+            map.Metadata = difficulty;
+            map.Metadata.mapName = SanitizeFilename(mapData._songName);
+            map.Metadata.songFilename = mapData._songFilename;
+            map.DifficultyData = loadedDiff;
+            return map;
         }
 
         /// <summary>

--- a/JoshaParity/Program.cs
+++ b/JoshaParity/Program.cs
@@ -2,25 +2,26 @@
 
 Console.WriteLine("<< Joshaparity Check! >>");
 
-string mapFolder = "./Maps";
-string formatString = "----------------------------------------------";
+const string mapFolder = "./Maps";
+const string formatString = "----------------------------------------------";
 
-// Change this to BeatmapDifficultyRank.All if you wish to do every difficulty
-BeatmapDifficultyRank _desiredDifficulty = BeatmapDifficultyRank.ExpertPlus;
-List<MapStructure> maps = new();
-
-// Map Example: "maps.Add(MapLoader.LoadMap($"{mapFolder}/Radiant"));"
-maps.Add(MapLoader.LoadMap($"{mapFolder}/Additional"));
-maps.Add(MapLoader.LoadMap($"{mapFolder}/Diastrophism"));
+// Change this to Beatmap DifficultyRank.All if you wish to do every difficulty
+const BeatmapDifficultyRank desiredDifficulty = BeatmapDifficultyRank.ExpertPlus;
+List<MapStructure> maps = new()
+{
+    // Map Example: "maps.Add(MapLoader.LoadMap($"{mapFolder}/Radiant"));"
+    MapLoader.LoadMap($"{mapFolder}/Additional"),
+    MapLoader.LoadMap($"{mapFolder}/Diastrophism"),
+    MapLoader.LoadMap($"{mapFolder}/Blood Moon"),
+    MapLoader.LoadMap($"{mapFolder}/BS Recall"),
+    MapLoader.LoadMap($"{mapFolder}/Compute"),
+    MapLoader.LoadMap($"{mapFolder}/Howl")
+};
 
 // Go through every map
 foreach (MapStructure map in maps)
 {
-    int totalDifficulties = 0;
-    for (int i = 0; i < map._difficultyBeatmapSets.Length; i++)
-    {
-        totalDifficulties += map._difficultyBeatmapSets[i]._difficultyBeatmaps.Length;
-    }
+    int totalDifficulties = map._difficultyBeatmapSets.Sum(t => t._difficultyBeatmaps.Length);
 
     if (totalDifficulties == 0) continue;
 
@@ -37,7 +38,7 @@ foreach (MapStructure map in maps)
         {
             foreach (DifficultyStructure difficulty in characteristic._difficultyBeatmaps)
             {
-                if (difficulty._difficultyRank == _desiredDifficulty || _desiredDifficulty == BeatmapDifficultyRank.All)
+                if (desiredDifficulty == BeatmapDifficultyRank.All || difficulty._difficultyRank == desiredDifficulty)
                 {
                     Console.WriteLine("Difficulty: " + difficulty._difficulty);
                     MapData diffData = MapLoader.LoadDifficultyData(map._mapFolder, difficulty, map);

--- a/JoshaParity/SwingDataGeneration.cs
+++ b/JoshaParity/SwingDataGeneration.cs
@@ -1,4 +1,5 @@
-﻿using JoshaParity;
+﻿using System.ComponentModel;
+using JoshaParity;
 using System.Numerics;
 
 namespace JoshaUtils
@@ -185,7 +186,7 @@ namespace JoshaUtils
 
             Console.WriteLine("Potential Bomb Reset Count: " + combinedSD.Count(x => x.resetType == ResetType.Bomb));
             Console.WriteLine("Potential Reset Count: " + combinedSD.Count(x => x.resetType == ResetType.Rebound));
-            //foreach (SwingData swing in rightHandSD) {
+            //foreach (SwingData swing in combinedSD) {
             //    Console.WriteLine(swing.ToString());
             //}
         }
@@ -295,7 +296,7 @@ namespace JoshaUtils
                 // Re-order the notesInCut in the event all the notes are dots and same snap
                 if (sData.notes.Count > 1 && sData.notes.All(x => x.d == 8))
                 {
-                    sData.notes = new(DotStackSort(lastSwing, sData.notes));
+                    notesInSwing = new(DotStackSort(lastSwing, sData.notes));
                     sData.SetStartPosition(notesInSwing[0].x, notesInSwing[0].y);
                     sData.SetEndPosition(notesInSwing[^1].x, notesInSwing[^1].y);
                 }
@@ -414,10 +415,10 @@ namespace JoshaUtils
             Vector2 atb = noteBPos - noteAPos;
 
             // In-case the last note was a dot, turn the swing angle into the closest cut direction based on last swing parity
-            int lastNoteClosestCutDir = ForehandDict.FirstOrDefault(x => x.Value == Math.Round(lastSwing.startPos.rotation / 45.0) * 45).Key;
+            int lastCutDirApprox = SwingDataGeneration.CutDirFromAngle(lastSwing.endPos.rotation, lastSwing.swingParity, 45.0f);
 
             // Convert the cut direction to a directional vector then do the dot product between noteA to noteB and last swing direction
-            Vector2 noteACutVector = DirectionalVectorToCutDirection.FirstOrDefault(x => x.Value == opposingCutDict[lastNoteClosestCutDir]).Key;
+            Vector2 noteACutVector = DirectionalVectorToCutDirection.FirstOrDefault(x => x.Value == opposingCutDict[lastCutDirApprox]).Key;
             float dotProduct = Vector2.Dot(noteACutVector, atb);
             if (dotProduct < 0)
             {
@@ -425,6 +426,7 @@ namespace JoshaUtils
             }
             else if (dotProduct == 0)
             {
+                Console.WriteLine(lastSwing.swingEndBeat);
                 // In the event its at a right angle, pick the note with the closest distance
                 Note lastNote = lastSwing.notes[^1];
 

--- a/JoshaParity/SwingDataGeneration.cs
+++ b/JoshaParity/SwingDataGeneration.cs
@@ -75,7 +75,7 @@ namespace JoshaUtils
         public override string ToString()
         {
             string returnString = $"Swing Note/s or Bomb/s {swingStartBeat} " +
-                $"| Parity of this swing: {swingParity}" +
+                                  $"| Parity of this swing: {swingParity}" + " | AFN: " + startPos.rotation+ 
                 $"\nPlayer Offset: {playerHorizontalOffset}x {playerVerticalOffset}y | " +
                 $"Swing EBPM: {swingEBPM} | Reset Type: {resetType}";
             return returnString;
@@ -185,9 +185,9 @@ namespace JoshaUtils
 
             Console.WriteLine("Potential Bomb Reset Count: " + combinedSD.Count(x => x.resetType == ResetType.Bomb));
             Console.WriteLine("Potential Reset Count: " + combinedSD.Count(x => x.resetType == ResetType.Rebound));
-            foreach (SwingData swing in combinedSD.Where(x => x.resetType == ResetType.Rebound)) {
-                Console.WriteLine("Potential " + swing.resetType + " at: " + swing.swingStartBeat);
-            }
+            //foreach (SwingData swing in rightHandSD) {
+            //    Console.WriteLine(swing.ToString());
+            //}
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace JoshaUtils
             List<Note> notesInSwing = new();
 
             // Attempt to find the notes for constructing this swing
-            for (int i = 0; i < _mapObjects.Notes.Count - 1; i++)
+            for (int i = 0; i <= _mapObjects.Notes.Count - 1; i++)
             {
                 Note currentNote = _mapObjects.Notes[i];
 
@@ -296,8 +296,8 @@ namespace JoshaUtils
                 if (sData.notes.Count > 1 && sData.notes.All(x => x.d == 8))
                 {
                     sData.notes = new(DotStackSort(lastSwing, sData.notes));
-                    sData.SetStartPosition(notesInSwing[0].d, notesInSwing[0].y);
-                    sData.SetEndPosition(notesInSwing[^1].d, notesInSwing[^1].y);
+                    sData.SetStartPosition(notesInSwing[0].x, notesInSwing[0].y);
+                    sData.SetEndPosition(notesInSwing[^1].x, notesInSwing[^1].y);
                 }
 
                 // Get swing EBPM, if reset then double
@@ -470,7 +470,6 @@ namespace JoshaUtils
 
             float change = lastSwing.endPos.rotation - angle;
             float altChange = lastSwing.endPos.rotation - altAngle;
-
 
             if (Math.Abs(altChange) < Math.Abs(change)) angle = altAngle;
 


### PR DESCRIPTION
Refactored bomb parity calculations to look for potential bomb reset conditions, then simulate moving the player and checking again as opposed to just checking all bombs between the last and next note. Approach supports bomb spirals and some forms of bomb decor better. Will still break on funky maps such as Rebuff.

- New Helper Function: CutDirFromAngle
- BeatGrid is a representation of the grid containing positions as either bomb or not bomb (will add note representation later)
- More consistent variable naming
- Simplified and cleaned code in places
- Better commenting for the entirety of the parity functionality