### PR TITLE
Fixes & Clean-up

### DIFF
--- a/JoshaParity/BPMHandler.cs
+++ b/JoshaParity/BPMHandler.cs
@@ -59,14 +59,14 @@ namespace JoshaParity
         public List<BPMChangeEvent> GetBPMChangeTime(List<BPMChangeEvent> bpmChanges)
         {
             // Order BPM Changes
-            bpmChanges = bpmChanges.OrderBy(bpm => bpm.b).ToList();
+            bpmChanges.OrderBy(bpm => bpm.b);
             List<BPMChangeEvent> alteredBPMChanges = new();
             BPMChangeEvent? temp = null;
 
             foreach (BPMChangeEvent curBPMChange in bpmChanges)
             {
                 curBPMChange.newTime = temp != null
-                    ? (float) Math.Ceiling((curBPMChange.b - temp.b) / _bpm * temp.m + temp.newTime - 0.01)
+                    ? (float)Math.Ceiling(((curBPMChange.b - temp.b) / _bpm) * temp.m + temp.newTime - 0.01)
                     : (float)Math.Ceiling(curBPMChange.b - (_offset * _bpm) / 60 - 0.01);
 
                 alteredBPMChanges.Add(curBPMChange);
@@ -84,8 +84,9 @@ namespace JoshaParity
         public List<BPMTimeScaler> GetTimeScale(List<BPMChangeEvent> bpmChanges)
         {
             // Order BPM Changes
-            bpmChanges = bpmChanges.OrderBy(bpm => bpm.b).ToList();
+            bpmChanges.OrderBy(bpm => bpm.b);
             List<BPMTimeScaler> timeScale = new();
+
             foreach (BPMChangeEvent bpm in bpmChanges)
             {
                 BPMTimeScaler ibpm = new()
@@ -105,11 +106,11 @@ namespace JoshaParity
         /// <param name="beat">Beat to Convert</param>
         /// <param name="timescale">Utilise Timescale?</param>
         /// <returns></returns>
-        public double ToRealTime(double beat, bool timescale = true)
+        public float ToRealTime(float beat, bool timescale = true)
         {
             if (!timescale) return (beat / _bpm) * 60;
 
-            double calculatedBeat = 0;
+            float calculatedBeat = 0;
             for (int i = _timeScale.Count - 1; i >= 0; i--)
             {
                 if (beat > _timeScale[i].t)
@@ -128,11 +129,11 @@ namespace JoshaParity
         /// <param name="seconds">Seconds to Convert</param>
         /// <param name="timescale">Utilise Timescale?</param>
         /// <returns></returns>
-        public double ToBeatTime(double seconds, bool timescale = false)
+        public float ToBeatTime(float seconds, bool timescale = false)
         {
             if (!timescale) return (seconds * _bpm) / 60;
 
-            double calculatedSecond = 0;
+            float calculatedSecond = 0;
             for (int i = _timeScale.Count - 1; i >= 0; i--)
             {
                 var currentSeconds = ToRealTime(_timeScale[i].t);
@@ -150,7 +151,7 @@ namespace JoshaParity
         /// </summary>
         /// <param name="beat">Beat to Convert</param>
         /// <returns></returns>
-        public double ToJsonTime(double beat)
+        public float ToJsonTime(float beat)
         {
             for (int i = _bpmChanges.Count - 1; i >= 0; i--)
             {
@@ -166,7 +167,7 @@ namespace JoshaParity
         /// Updates the current BPM value stored based on BPM Changes and provided beat value
         /// </summary>
         /// <param name="beat">Beat to Get BPM at</param>
-        public void SetCurrentBPM(double beat)
+        public void SetCurrentBPM(float beat)
         {
             for (int i = 0; i < _bpmChanges.Count; i++)
             {
@@ -182,8 +183,8 @@ namespace JoshaParity
         /// </summary>
         public class BPMTimeScaler
         {
-            public double t;
-            public double s;
+            public float t;
+            public float s;
         }
 
         /// <summary>
@@ -193,8 +194,8 @@ namespace JoshaParity
         {
             public float b;
             public float m;
-            public float p;
-            public float o;
+            public float p = 0;
+            public float o = 0;
             public float newTime;
 
             public BPMChangeEvent(BPMEvent bpmEvent)

--- a/JoshaParity/Core/MapSwingClassifier.cs
+++ b/JoshaParity/Core/MapSwingClassifier.cs
@@ -75,9 +75,6 @@ namespace JoshaParity
                 _constructedSwing = new List<Note>(_notesBuffer);
             }
 
-            // Attempt to sort snapped swing if not all dots
-            if (_constructedSwing.Count > 1 && _constructedSwing.All(x => x.b == _constructedSwing[0].b)) _constructedSwing = SwingUtils.SnappedSwingSort(_constructedSwing);
-
             // Stack classification
             SwingType returnType = SwingType.Normal;
             if (_constructedSwing.All(x => x.ms == _constructedSwing[0].ms) && _constructedSwing.Count > 1)

--- a/JoshaParity/Core/SwingData.cs
+++ b/JoshaParity/Core/SwingData.cs
@@ -31,6 +31,7 @@ namespace JoshaParity
         public PositionData startPos;
         public PositionData endPos;
         public bool rightHand;
+        public bool upsideDown;
         public Vector2 playerOffset;
 
         /// <summary>
@@ -49,6 +50,7 @@ namespace JoshaParity
             endPos = new PositionData();
             rightHand = true;
             playerOffset = Vector2.Zero;
+            upsideDown = false;
         }
 
         /// <summary>

--- a/JoshaParity/Core/SwingData.cs
+++ b/JoshaParity/Core/SwingData.cs
@@ -93,6 +93,8 @@ namespace JoshaParity
         public void SetEndPosition(float x, float y) { endPos.x = x; endPos.y = y; }
         public void SetStartAngle(float angle) { startPos.rotation = angle; }
         public void SetEndAngle(float angle) { endPos.rotation = angle; }
+        public void SetUpsideDown(bool upsideDown) { this.upsideDown = upsideDown; }
+        public void SetResetType(ResetType resetType) { this.resetType = resetType; }
         public bool IsReset => resetType != 0;
 
         /// <summary>

--- a/JoshaParity/Core/SwingData.cs
+++ b/JoshaParity/Core/SwingData.cs
@@ -64,7 +64,7 @@ namespace JoshaParity
         public SwingData(SwingType type, List<Note> swingNotes, bool rightHand, bool startingSwing = false)
         {
             // Attempt to sort snapped swing if not all dots
-            if (swingNotes.Count > 1 && swingNotes.All(x => Math.Abs(swingNotes[0].b) - x.b < 0.01f)) { notes = new(SwingUtils.SnappedSwingSort(swingNotes)); }
+            if (swingNotes.Count > 1 && swingNotes.All(x => Math.Abs(swingNotes[0].b) - x.b < 0.01f) && type != SwingType.Chain) { notes = new(SwingUtils.SnappedSwingSort(swingNotes)); }
             else { notes = new(swingNotes); }
 
             swingParity = Parity.Undecided;

--- a/JoshaParity/Core/SwingData.cs
+++ b/JoshaParity/Core/SwingData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace JoshaParity
@@ -23,6 +24,8 @@ namespace JoshaParity
         public ResetType resetType;
         public float swingStartBeat;
         public float swingEndBeat;
+        public float swingStartSeconds;
+        public float swingEndSeconds;
         public float swingEBPM;
         public List<Note> notes = new();
         public PositionData startPos;
@@ -57,15 +60,18 @@ namespace JoshaParity
         /// <param name="startingSwing">Is this the first swing in the map?</param>
         public SwingData(SwingType type, List<Note> notes, bool rightHand, bool startingSwing = false)
         {
-            this.notes = notes;
+            // Attempt to sort snapped swing if not all dots
+            if (notes.Count > 1 && notes.All(x => x.b == notes[0].b)) { this.notes = SwingUtils.SnappedSwingSort(notes); }
+            else {  this.notes = notes; }
+
             swingParity = Parity.Undecided;
             swingType = type;
             swingStartBeat = notes[0].b;
             swingEndBeat = notes[notes.Count - 1].b;
             this.rightHand = rightHand;
 
-            SetStartPosition(notes[0].x, notes[0].y);
-            SetEndPosition(notes[notes.Count - 1].x, notes[notes.Count - 1].y);
+            SetStartPosition(this.notes[0].x, this.notes[0].y);
+            SetEndPosition(this.notes[this.notes.Count - 1].x, this.notes[this.notes.Count - 1].y);
 
             // If its the first swing, we guess parity for first hit
             if (startingSwing)

--- a/JoshaParity/Core/SwingData.cs
+++ b/JoshaParity/Core/SwingData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
@@ -60,11 +61,11 @@ namespace JoshaParity
         /// <param name="notes">Notes making up this swing</param>
         /// <param name="rightHand">Are the notes right handed?</param>
         /// <param name="startingSwing">Is this the first swing in the map?</param>
-        public SwingData(SwingType type, List<Note> notes, bool rightHand, bool startingSwing = false)
+        public SwingData(SwingType type, List<Note> swingNotes, bool rightHand, bool startingSwing = false)
         {
             // Attempt to sort snapped swing if not all dots
-            if (notes.Count > 1 && notes.All(x => x.b == notes[0].b)) { this.notes = SwingUtils.SnappedSwingSort(notes); }
-            else {  this.notes = notes; }
+            if (swingNotes.Count > 1 && swingNotes.All(x => Math.Abs(swingNotes[0].b) - x.b < 0.01f)) { notes = new(SwingUtils.SnappedSwingSort(swingNotes)); }
+            else { notes = new(swingNotes); }
 
             swingParity = Parity.Undecided;
             swingType = type;
@@ -72,8 +73,8 @@ namespace JoshaParity
             swingEndBeat = notes[notes.Count - 1].b;
             this.rightHand = rightHand;
 
-            SetStartPosition(this.notes[0].x, this.notes[0].y);
-            SetEndPosition(this.notes[this.notes.Count - 1].x, this.notes[this.notes.Count - 1].y);
+            SetStartPosition(notes[0].x, notes[0].y);
+            SetEndPosition(notes[notes.Count - 1].x, notes[notes.Count - 1].y);
 
             // If its the first swing, we guess parity for first hit
             if (startingSwing)

--- a/JoshaParity/Core/TimeUtils.cs
+++ b/JoshaParity/Core/TimeUtils.cs
@@ -39,7 +39,7 @@ namespace JoshaParity
         }
 
         /// <summary>
-        /// Converts a length in beats into seconds given BPM and beats disregarding BPM Changes
+        /// Converts a length in beats into seconds given persistent BPM and a beat, disregarding BPM Changes
         /// </summary>
         /// <param name="BPM">Beats per minute of the map</param>
         /// <param name="beats">Length of time in beats</param>
@@ -47,6 +47,19 @@ namespace JoshaParity
         public static float BeatToSeconds(float BPM, float beats)
         {
             return (beats / (BPM / 60));
+        }
+
+        /// <summary>
+        /// Converts 2 points in time (in beats) and returns the seconds, accounting for BPM Changes
+        /// </summary>
+        /// <param name="bpmHandler">BPMHandler for the map</param>
+        /// <param name="startBeat">Beat time of last swing</param>
+        /// <param name="endBeat">Beat time of current swing</param>
+        /// <returns></returns>
+        public static float BeatsToSeconds(BPMHandler bpmHandler, float startBeat, float endBeat)
+        {
+            if (startBeat == 0 && endBeat == 0) { return 0; }
+            return bpmHandler.ToRealTime(endBeat) - bpmHandler.ToRealTime(startBeat);
         }
 
         /// <summary>

--- a/JoshaParity/Core/TimeUtils.cs
+++ b/JoshaParity/Core/TimeUtils.cs
@@ -25,15 +25,17 @@ namespace JoshaParity
         }
 
         /// <summary>
-        /// Returns the effective BPM of a swing given time in beats and song BPM
+        /// Returns the effective BPM of a swing given BPM Info and 2 points
         /// </summary>
         /// <param name="bpmHandler">BPMHandler for the map</param>
-        /// <param name="beats">Time between 2 swings in beats</param>
+        /// <param name="startBeat">Beat time of last swing</param>
+        /// <param name="endBeat">Beat time of current swing</param>
         /// <returns></returns>
-        public static float SwingEBPM(BPMHandler bpmHandler, float beats)
+        public static float SwingEBPM(BPMHandler bpmHandler, float startBeat, float endBeat)
         {
-            double seconds = bpmHandler.ToRealTime(beats);
-            return (float)(60 / (2 * seconds));
+            if (startBeat == 0 && endBeat == 0) { return 0; }
+            float secondsDiff = bpmHandler.ToRealTime(endBeat) - bpmHandler.ToRealTime(startBeat);
+            return (float)(60 / (2 * secondsDiff));
         }
 
         /// <summary>

--- a/JoshaParity/GenericParityCheck.cs
+++ b/JoshaParity/GenericParityCheck.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Xml.Linq;
 
 namespace JoshaParity
 {

--- a/JoshaParity/IParityMethod.cs
+++ b/JoshaParity/IParityMethod.cs
@@ -7,7 +7,6 @@ namespace JoshaParity
     /// </summary>
     public interface IParityMethod
     {
-        Parity ParityCheck(SwingData lastSwing, ref SwingData currentSwing, List<Bomb> bombs, float timeTillNextNote = 0.1f);
-        bool UpsideDown { get; }
+        Parity ParityCheck(ParityCheckContext context);
     }
 }

--- a/JoshaParity/IParityMethod.cs
+++ b/JoshaParity/IParityMethod.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace JoshaParity
+﻿namespace JoshaParity
 {
     /// <summary>
     /// A method that takes in a swing and the next swing to come, bombs and time till next note and returns a parity prediction

--- a/JoshaParity/IParityMethod.cs
+++ b/JoshaParity/IParityMethod.cs
@@ -1,10 +1,10 @@
 ﻿namespace JoshaParity
 {
     /// <summary>
-    /// A method that takes in a swing and the next swing to come, bombs and time till next note and returns a parity prediction
+    /// A method that takes in a swing and Parity Context then determines the current Parity
     /// </summary>
     public interface IParityMethod
     {
-        Parity ParityCheck(ParityCheckContext context);
+        Parity ParityCheck(ref SwingData currentSwing, ParityCheckContext context);
     }
 }

--- a/JoshaParity/JoshaParity.csproj
+++ b/JoshaParity/JoshaParity.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="ExperimentalBombTest.cs" />
     <Compile Remove="Program.cs" />
   </ItemGroup>
 

--- a/JoshaParity/JoshaParity.csproj
+++ b/JoshaParity/JoshaParity.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="ExperimentalBombTest.cs" />
     <Compile Remove="Program.cs" />
   </ItemGroup>
 

--- a/JoshaParity/JoshaParity.csproj
+++ b/JoshaParity/JoshaParity.csproj
@@ -6,7 +6,7 @@
 	<LangVersion>latest</LangVersion>
     <ImplicitUsings>disabled</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.3.2</Version>
+    <Version>1.3.3</Version>
     <Company>Joshabi</Company>
   </PropertyGroup>
 

--- a/JoshaParity/SwingDataGeneration.cs
+++ b/JoshaParity/SwingDataGeneration.cs
@@ -176,7 +176,7 @@ namespace JoshaParity
 
             // Calculate the time since the last note of the last swing, then attempt to determine this swings parity
             float timeSinceLastNote = Math.Abs(currentNote.ms - lastSwing.notes[lastSwing.notes.Count - 1].ms);
-            sData.swingParity = ParityMethodology.ParityCheck(lastSwing, ref sData, bombsBetweenSwings, timeSinceLastNote);
+            sData.swingParity = ParityMethodology.ParityCheck(new ParityCheckContext(ref sData, curState, mapData));
 
             // Setting Angles
             if (sData.notes.Count == 1)
@@ -211,8 +211,8 @@ namespace JoshaParity
                     SwingUtils.SliderAngleCalc(ref sData);
                 }
             }
-            // Temporary, will be replaced with new lean system once implemented.
-            if (ParityMethodology.UpsideDown == true)
+
+            if (sData.upsideDown)
             {
                 if (sData.notes.All(x => x.d != 8))
                 {
@@ -220,6 +220,7 @@ namespace JoshaParity
                     sData.SetEndAngle(sData.endPos.rotation * -1);
                 }
             }
+
             return sData;
         }
 

--- a/JoshaParity/SwingDataGeneration.cs
+++ b/JoshaParity/SwingDataGeneration.cs
@@ -52,7 +52,6 @@ namespace JoshaParity
         {
             ParityMethodology = parityMethod ??= new GenericParityCheck();
             BpmHandler = BPMHandler;
-            //mainContainer.lastDodgeTime = 0; mainContainer.lastDuckTime = 0;
             mainContainer = new();
 
             // Separate notes, bombs, walls and burst sliders
@@ -153,6 +152,8 @@ namespace JoshaParity
             bool firstSwing = false;
             if ((isRightHand && curState.RightHandSwings.Count == 0) || (!isRightHand && curState.LeftHandSwings.Count == 0)) firstSwing = true;
             SwingData sData = new SwingData(type, notes, isRightHand, firstSwing);
+            sData.swingStartSeconds = (float)BpmHandler.ToRealTime(sData.swingStartBeat);
+            sData.swingEndSeconds = (float)BpmHandler.ToRealTime(sData.swingEndBeat);
 
             // If first we leave
             if (firstSwing) return sData;

--- a/JoshaParity/SwingDataGeneration.cs
+++ b/JoshaParity/SwingDataGeneration.cs
@@ -171,11 +171,7 @@ namespace JoshaParity
             sData.swingEBPM = TimeUtils.SwingEBPM(BpmHandler, currentNote.b - lastNote.b);
             if (lastSwing.IsReset) { sData.swingEBPM *= 2; }
 
-            // Get bombs between swings
-            List<Bomb> bombsBetweenSwings = mapData.Bombs.FindAll(x => x.b > lastNote.b + 0.01f && x.b < sData.notes[sData.notes.Count - 1].b - 0.01f);
-
-            // Calculate the time since the last note of the last swing, then attempt to determine this swings parity
-            float timeSinceLastNote = Math.Abs(currentNote.ms - lastSwing.notes[lastSwing.notes.Count - 1].ms);
+            // Calculate Parity
             sData.swingParity = ParityMethodology.ParityCheck(new ParityCheckContext(ref sData, curState, mapData));
 
             // Setting Angles

--- a/JoshaParity/SwingDataGeneration.cs
+++ b/JoshaParity/SwingDataGeneration.cs
@@ -66,7 +66,6 @@ namespace JoshaParity
 
             // Set MS values for notes
             foreach (Note note in notes) {
-                BpmHandler.SetCurrentBPM(note.b);
                 float beatMS = 60 * 1000 / BpmHandler.BPM;
                 note.ms = beatMS * note.b;
             }
@@ -99,7 +98,6 @@ namespace JoshaParity
             {
                 Note currentNote = mapObjects.Notes[i];
                 currentNote = SwingUtils.ValidateNote(currentNote);
-                BpmHandler.SetCurrentBPM(currentNote.b);
 
                 // Depending on hand, update buffer
                 if (currentNote.c == 0) { 
@@ -152,8 +150,8 @@ namespace JoshaParity
             bool firstSwing = false;
             if ((isRightHand && curState.RightHandSwings.Count == 0) || (!isRightHand && curState.LeftHandSwings.Count == 0)) firstSwing = true;
             SwingData sData = new SwingData(type, notes, isRightHand, firstSwing);
-            sData.swingStartSeconds = (float)BpmHandler.ToRealTime(sData.swingStartBeat);
-            sData.swingEndSeconds = (float)BpmHandler.ToRealTime(sData.swingEndBeat);
+            sData.swingStartSeconds = BpmHandler.ToRealTime(sData.swingStartBeat);
+            sData.swingEndSeconds = BpmHandler.ToRealTime(sData.swingEndBeat);
 
             // If first we leave
             if (firstSwing) return sData;

--- a/JoshaParity/SwingDataGeneration.cs
+++ b/JoshaParity/SwingDataGeneration.cs
@@ -195,7 +195,7 @@ namespace JoshaParity
             {
                 // Multi Note Hits
                 // If Snapped
-                if (sData.notes.All(x => x.b == sData.notes[0].b))
+                if (sData.notes.All(x => Math.Abs(sData.notes[0].b) - x.b < 0.01f))
                 {
                     if (sData.notes.All(x => x.d == 8)) { SwingUtils.SnappedDotSwingAngleCalc(lastSwing, ref sData); }
                     else { SwingUtils.SliderAngleCalc(ref sData); }

--- a/README.md
+++ b/README.md
@@ -4,30 +4,35 @@
 Algorithmically attempts to predict how a map is played based on configured Parity Rules. Logic
 for parity decisions can be hotswapped by creating a new checker class inhereting from
 `IParityMethod`, with an implementation of `ParityCheck` that stores the logic. It is worth noting this swing data
-persists to only where notes are and resets.
+persists to only where notes / swings are, and does not include inbetween bomb avoidance or similar.
 
-To analyze an entire mapset, you create a `MapAnalyser` with the map's folder path, and
-it will load the necessary files. Then, it generates a list of `SwingData` that predict how the map is played.
+## Usage
+
+To analyze an entire mapset, create a `MapAnalyser` using the folder path and it will handle loading the map and difficulties.
+You can then retrieve the `MapSwingContainer` for any given difficulty.
 **Example:**
 ```C#
 MapAnalyser Diastrophism = new MapAnalyser("./Maps/Diastrophism");
-```
-You can pass in your own `IParityCheck` implementation to change the parity logic of this analyser:
-```C#
-MapAnalyser SetsunaImitation = new MapAnalyser("./Maps/SetsunaImitation", true, new ExperimentalBombTest());
+DiffAnalysis ExpertPlus = Diastrophism.GetDiffAnalysis(BeatmapDifficultyRank.ExpertPlus);
+List<SwingData> Result = ExpertPlus.GetJointSwingData();
 ```
 
-**Alternatively,** you can run on an individual difficulty by loading the difficulty.dat and info.dat files into strings. For example:
+**Alternatively:** 
+You can run on an individual difficulty by loading the difficulty.dat and either info.dat contents or bpm and songtime offset values, For example:
+
+**Info.dat Contents:**
 ```C#
 string infoContents = File.ReadAllText("File Path of Info.dat Here"); 
 string difContents = File.ReadAllText("File Path of ExpertPlusStandard.dat Here for example");
-DiffAnalysis expertPlus = new DiffAnalysis(infoContents, difContents, BeatmapDifficultyRank.ExpertPlus);
+DiffAnalysis ExpertPlus = new DiffAnalysis(difContents, infoContents, BeatmapDifficultyRank.ExpertPlus);
 ```
-
-This `DiffAnalysis` can be retrieved if you use a `MapAnalyser` via:
+**BPM and Offset Info:**
 ```C#
-DiffAnalysis expertPlus = mapAnalyser.GetDiffAnalysis(BeatmapDifficultyRank.ExpertPlus);
+float bpm, songTimeOffset
+string difContents = File.ReadAllText("File Path of ExpertPlusStandard.dat Here for example");
+DiffAnalysis ExpertPlus = new DiffAnalysis(difContents, bpm, BeatmapDifficultyRank.ExpertPlus, songTimeOffset);
 ```
+## Statistics
 
 `DiffAnalysis` functionalities include:
 - `GetSPS` - Returns the Average Swings Per Second of the data;
@@ -39,18 +44,34 @@ DiffAnalysis expertPlus = mapAnalyser.GetDiffAnalysis(BeatmapDifficultyRank.Expe
 - `GetDoublesPercent` - Returns % of the map that are "doubles";
 - `SwingContainer` - You can directly access a difficulties `SwingContainer` to retrieve LeanData, (player)`OffsetData` and more;
 
+With several of the above functionalities, you can specify a `HandResult` value to get data only considering one or both hands.
+I intend on implementing way more statistics that currently are available in the future.
+
+## Contributions
+
 **Thanks to:**
-- Jindo, for allowing me to transfer v2 to v3 conversion function from the JindoRankTool.
+- Jindo, for the initial V2->V3 Conversion and all the help whilst it was used in JindoRankTool
+- Pink, for the motivation boost and help with both this and the bot
+- Light and Loloppe, for all the help and for using this in AutoModder
 
 **JoshaParity used in:**
 - [JindoRankTool](https://github.com/oshannonlepper/JindoRankTool) (As: Library)
 - [AutoModder](https://github.com/LightAi39/ChroMapper-AutoModder) (As: Library)
 
+## Issues and Goals
+
 **Known Issues:**
-- [Minor] Using fixed definitions of bomb resets isn't always correct, and more complex solutions also have issues. Currently, I am
-  attempting to rework and reapproach this problem by making it try resetting and not resetting, then seeing which path is better.
+- [Minor] Bomb resets and decor can trigger or not trigger bomb resets when the opposite was expected. This is relatively complex
+  to fix as the same configuration of bombs can mean different things based on a lot of context. I will improve this over-time,
+  hopefully through the use of simulating both outcomes.
+
+**Important:**
+- [Major] I will be depreciating use of passing in IParityCheck in favour of a more modular and customizeable approach.
 
 **Goals:**
 - Add a configuration system so parity values and other aspects can be tweaked externally
 - Allow multiple paths to be tried for bomb resets to improve reset detection
 - Allow multiple paths to be tried with some metric for success to allow more realistic playing for JoshaBot
+- Add Lean to and overhaul Parity Calculation using a shifting dictionary
+- Parity path of least resistance and least strain calculations
+- Able to interface directly with both base-game object types, MapLoader types and BL-Parser types


### PR DESCRIPTION
## Changes:
- Parity now takes in a context object in preparation for overhaul
- DiffAnalysis constructors have been refactored
- Statistics can now be retrieved on a per-hand basis
- Cleaned-up loading
- Cleaned-up V2->V3 conversion
- You can now retrieve SwingData with resetSwings inserted again through MapSwingContainer static function
- Added swingStartSeconds and swingEndSeconds as well as cleaned up SwingData
- Swing sorting now occurs in construction

## Fixes:
- Fixed type consistency in BPMHandler
- Fixed incorrect beat and seconds values for swings when Official BPM Changes are present
- Fixed issue where notes with minute differences would not count as snapped (e.g. C18 has some windows where the notes have like 0.0001 difference or similar so failed the "snapped" test)
- Fixed some inconsistent commenting
- Fixed note MS not accounting for BPM Changes
- Fixed EBPM not calculating correctly (It was treating the beat difference as a beat time stamp)
- Chains are no longer ordered or have their angle calced